### PR TITLE
Add accessors for polyhedron representations

### DIFF
--- a/include/sch/Python/SCHAddon.h
+++ b/include/sch/Python/SCHAddon.h
@@ -59,13 +59,12 @@ namespace sch
   }
 
 
-  S_Object* Polyhedron(const std::string& filename)
+  S_Polyhedron* Polyhedron(const std::string& filename)
   {
     S_Polyhedron* s = new S_Polyhedron;
     s->constructFromFile(filename);
     return s;
   }
-
 
   double distance(CD_Pair& pair, Eigen::Vector3d& p1, Eigen::Vector3d& p2)
   {
@@ -76,6 +75,46 @@ namespace sch
     p2 << p2Tmp[0], p2Tmp[1], p2Tmp[2];
 
     return dist;
+  }
+
+  std::vector<Eigen::Vector3d> vertices(S_Polyhedron& poly)
+  {
+    const Polyhedron_algorithms* pa = poly.getPolyhedronAlgorithm();
+    std::vector<Eigen::Vector3d> vec;
+    vec.reserve(pa->vertexes_.size());
+    for(std::size_t i = 0; i < pa->triangles_.size(); ++i)
+    {
+      Vector3 normal = pa->triangles_[i].normal;
+      vec.push_back(Eigen::Vector3d(normal[0], normal[1], normal[2]));
+    }
+    return vec;
+  }
+
+  std::vector<Eigen::Vector3d> normals(S_Polyhedron& poly)
+  {
+    const Polyhedron_algorithms* pa = poly.getPolyhedronAlgorithm();
+    std::vector<Eigen::Vector3d> vec;
+    vec.reserve(pa->triangles_.size());
+    for(std::size_t i = 0; i < pa->vertexes_.size(); ++i)
+    {
+      Vector3 coordinates = pa->vertexes_[i]->getCordinates();
+      vec.push_back(Eigen::Vector3d(coordinates[0], coordinates[1], coordinates[2]));
+    }
+    return vec;
+  }
+
+  std::vector<std::vector<unsigned int> > triangles(S_Polyhedron& poly)
+  {
+    const Polyhedron_algorithms* pa = poly.getPolyhedronAlgorithm();
+    std::vector<std::vector<unsigned int>> vec;
+    vec.reserve(pa->triangles_.size());
+    for(std::size_t i = 0; i < pa->vertexes_.size(); ++i)
+    {
+      const PolyhedronTriangle triangle = pa->triangles_[i];
+      std::vector<unsigned int> tri = {triangle.a, triangle.b, triangle.c};
+      vec.push_back(tri);
+    }
+    return vec;
   }
 
 }

--- a/src/generate.py
+++ b/src/generate.py
@@ -30,11 +30,30 @@ def import_eigen3_types(mod):
 def import_sva_types(mod):
   mod.add_class('PTransformd', foreign_cpp_namespace='sva', import_from_module='spacevecalg')
 
-
+def build_sch_containers(sch):
+  sch.add_container('std::vector<Eigen::Vector3d>',
+                    'Eigen::Vector3d',
+                    'vector')
+  sch.add_container('std::vector<unsigned int>', 'unsigned int', 'vector')
+  sch.add_container('std::vector<std::vector<unsigned int> >', 'std::vector<unsigned int>', 'vector')
 
 def build_sch(sch):
   obj = sch.add_class('S_Object')
   pair = sch.add_class('CD_Pair')
+  polyhedron = sch.add_class('S_Polyhedron', parent=obj)
+
+  polyhedron.add_function_as_method('vertices', 'std::vector<Eigen::Vector3d>',
+                                    [param('sch::S_Polyhedron', 'poly')],
+                                    custom_name='vertices')
+
+  polyhedron.add_function_as_method('triangles', 'std::vector<std::vector<unsigned int> >',
+                                    [param('sch::S_Polyhedron', 'poly')],
+                                    custom_name='triangles')
+
+  polyhedron.add_function_as_method('normals', 'std::vector<Eigen::Vector3d>',
+                                    [param('sch::S_Polyhedron', 'poly')],
+                                    custom_name='normals')
+
 
   obj.add_function_as_method('transform', None, [param('sch::S_Object&', 'obj'),
                                                  param('const sva::PTransformd&', 'trans')],
@@ -49,7 +68,7 @@ def build_sch(sch):
                     param('double', 'z')])
   sch.add_function('STPBV', retval('sch::S_Object*', caller_owns_return=True),
                    [param('const std::string&', 'filename')])
-  sch.add_function('Polyhedron', retval('sch::S_Object*', caller_owns_return=True),
+  sch.add_function('Polyhedron', retval('sch::S_Polyhedron*', caller_owns_return=True),
                    [param('const std::string&', 'filename')])
 
 
@@ -77,6 +96,8 @@ if __name__ == '__main__':
   sch.add_include('<sch/S_Object/S_Sphere.h>')
   sch.add_include('<sch/S_Object/S_Box.h>')
   sch.add_include('<sch/S_Polyhedron/S_Polyhedron.h>')
+  sch.add_include('<sch/S_Polyhedron/S_PolyhedronVertex.h>')
+  sch.add_include('<sch/S_Polyhedron/Polyhedron_algorithms.h>')
   sch.add_include('<sch/STP-BV/STP_BV.h>')
   sch.add_include('<sch/CD/CD_Pair.h>')
 
@@ -92,6 +113,7 @@ if __name__ == '__main__':
   import_sva_types(sch)
 
   # sch
+  build_sch_containers(sch)
   build_sch(sch)
 
   with open(sys.argv[1], 'w') as f:


### PR DESCRIPTION
- Add three methods on a polyhedron object: vertices, normals, triangles
- Vertices is a vector of Eigen::Vector3d
- Normals is a vector of Eigen::Vector3d
- Triangles is a vector of triplets of ints (implemented as
- std::vector), in the same order as normals. Each triplet represent
  indicices of the vertices forming that triangle.

NB: This changes the signature of the Polyhedron() method, to return a
S_Polyhedron instead of a plain S_Object.

Now, one can do this:

``` python
import eigen3 as e3
import sch

poly = sch.Polyhedron(filepath)
vertices = [e3.toNumpy(v) for v in poly.vertices()]
normals = [e3.toNumpy(n) for n in poly.normals()]
triangles = [list(t) for t in poly.triangles]
```

I haven't done much testing yet, and I don't know if we have a test suite for sch-core python. I will experiment a bit with the feature before merging.

Implementation notes:
- One can not directly access the vertices_ of a Polyhedron_Algorithms: they are not copyable but pybindgen cannot create a std::vector of a non-copyable type. Thus the need for external functions.
- Pybindgen does not [seem to support](https://pythonhosted.org/PyBindGen/container.html) neither pairs nor array, hence the `std::vector<std::vector<unsigned int> >` for triangles. If someone has time, it would be nice to check if it would be possible to turn it into `std::vector<std::array<3, unsigned int>>` or `std::vector< std::tuple<uint, uint, uint>>`.
- I wanted to hide S_Polyhedron by not importing it in **init**.py, but it seems I removed too many imports and this crashed the controller.

Cheers,
Hervé
