### PR TITLE
Added a check in case that boost options don't appear

### DIFF
--- a/setup.in.py
+++ b/setup.in.py
@@ -63,6 +63,7 @@ def GenExtension(name, pkg, ):
   cpp_src = pyx_src + '.cpp'
   pyx_src = pyx_src + '.pyx'
   ext_src = pyx_src
+  pkg.include_dirs=list(pkg.include_dirs)
   return Extension(name, [ext_src], extra_compile_args = pkg.compile_args, include_dirs = pkg.include_dirs + [numpy.get_include()], library_dirs = pkg.library_dirs, libraries = pkg.libraries)
 
 extensions = [

--- a/setup.in.py
+++ b/setup.in.py
@@ -45,7 +45,8 @@ class pkg_config(object):
     if win32_build:
         self.compile_args.append('-DWIN32')
     self.include_dirs = [ x for x in '$<TARGET_PROPERTY:SpaceVecAlg::SpaceVecAlg,INTERFACE_INCLUDE_DIRECTORIES>;$<TARGET_PROPERTY:sch-core::sch-core,INCLUDE_DIRECTORIES>'.split(';') if len(x) ]
-    self.include_dirs.append('@Boost_INCLUDE_DIR@')
+    if '@Boost_INCLUDE_DIR@' != '':
+      self.include_dirs.append('@Boost_INCLUDE_DIR@')
     self.include_dirs.append(this_path + '/include')
     self.library_dirs = [ x for x in '$<TARGET_PROPERTY:sch-core::sch-core,LINK_FLAGS>'.split(';') if len(x) ]
     location = '$<TARGET_PROPERTY:sch-core::sch-core,LOCATION_$<CONFIGURATION>>'

--- a/setup.in.py
+++ b/setup.in.py
@@ -45,9 +45,10 @@ class pkg_config(object):
     if win32_build:
         self.compile_args.append('-DWIN32')
     self.include_dirs = [ x for x in '$<TARGET_PROPERTY:SpaceVecAlg::SpaceVecAlg,INTERFACE_INCLUDE_DIRECTORIES>;$<TARGET_PROPERTY:sch-core::sch-core,INCLUDE_DIRECTORIES>'.split(';') if len(x) ]
-    if '@Boost_INCLUDE_DIR@' != '':
-      self.include_dirs.append('@Boost_INCLUDE_DIR@')
+    #if '@Boost_INCLUDE_DIR@' != '':
+    self.include_dirs.append('@Boost_INCLUDE_DIR@')
     self.include_dirs.append(this_path + '/include')
+    self.include_dirs = filter(len, self.include_dirs)
     self.library_dirs = [ x for x in '$<TARGET_PROPERTY:sch-core::sch-core,LINK_FLAGS>'.split(';') if len(x) ]
     location = '$<TARGET_PROPERTY:sch-core::sch-core,LOCATION_$<CONFIGURATION>>'
     self.library_dirs.append(os.path.dirname(location) + "/../lib/")

--- a/setup.in.py
+++ b/setup.in.py
@@ -45,7 +45,6 @@ class pkg_config(object):
     if win32_build:
         self.compile_args.append('-DWIN32')
     self.include_dirs = [ x for x in '$<TARGET_PROPERTY:SpaceVecAlg::SpaceVecAlg,INTERFACE_INCLUDE_DIRECTORIES>;$<TARGET_PROPERTY:sch-core::sch-core,INCLUDE_DIRECTORIES>'.split(';') if len(x) ]
-    #if '@Boost_INCLUDE_DIR@' != '':
     self.include_dirs.append('@Boost_INCLUDE_DIR@')
     self.include_dirs.append(this_path + '/include')
     self.include_dirs = filter(len, self.include_dirs)


### PR DESCRIPTION
For some reason, while installing on the computer of HRP-5P, the options of boost didn't appear in ccmake, and '@Boost_INCLUDE_DIR@' = ''

That broke the installation, as the following error appeared while compiling:

x86_64-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2-g -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/eigen3 -I/usr/local/include -I-I/home/hrp5puser/src/jrl/sch-core-python/build/python/include -I/usr/lib/python2.7/dist-packages/numpy/core/include-I/usr/include/python2.7 -c sch/sch.cpp -o build/temp.linux-x86_64-2.7/sch/sch.o -std=c++11
cc1plus: warning: command line option ‘-Wstrict-prototypes’ is valid for C/ObjC but not for C++
sch/sch.cpp:290:27: fatal error: sch_wrapper.hpp: そのようなファイルやディレクトリはありません

As you can see there is a '-I' without path just before '-I/home/hrp5puser/src/jrl/sch-core-python/build/python/include'